### PR TITLE
Problem: cargo was not available as part of the toolchain.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ git checkout "$RUST_COMMIT"
 cd ..
 mkdir -p rust-build
 cd rust-build
-../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios
+../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios --enable-extended --tools=cargo
 export RUSTFLAGS_NOT_BOOTSTRAP=-Zembed-bitcode
 export CFLAGS_aarch64_apple_ios=-fembed-bitcode
 python "$WORKING_DIR/rust/x.py" build

--- a/install.sh
+++ b/install.sh
@@ -7,5 +7,6 @@ DEST_TOOLCHAIN="$HOME/.rust-ios-arm64/toolchain-$RUST_NIGHTLY"
 
 mkdir -p "$DEST_TOOLCHAIN"
 cp -r "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2"/* "$DEST_TOOLCHAIN"
+cp -r "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2-tools/x86_64-apple-darwin/release/cargo" "$DEST_TOOLCHAIN/bin"
 
 rustup toolchain link ios-arm64 "$DEST_TOOLCHAIN"


### PR DESCRIPTION
Solution: Ensure that cargo is built as part of the toolchain by enabling the
build to be extended (`--enable-extended`) and specifying cargo in the set of
tools to be built (`--tools=cargo`), both in build.sh.

Add a line in install.sh to copy the built cargo binary to the toolchain's
installation directory.

---

For what it's worth I tested this with this config:

```
RUST_NIGHTLY="2020-01-17"
RUST_COMMIT="488406183"
```

and the same LLVM branch as is on master.