### PR TITLE
Using apple/llvm-project instead of apple/swift-llvm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,12 +16,12 @@ fi
 
 cd "$WORKING_DIR"
 if [ ! -d "$WORKING_DIR/llvm-project" ]; then
-    git clone https://github.com/apple/llvm-project.git -b "$LLVM_BRANCH"
+    git clone https://github.com/apple/llvm-project.git
 fi
 cd "$WORKING_DIR/llvm-project"
 git reset --hard
 git clean -f
-git checkout "origin/$LLVM_BRANCH"
+git checkout "$LLVM_BRANCH"
 cd ..
 
 mkdir -p llvm-build
@@ -37,7 +37,7 @@ fi
 cd rust
 git reset --hard
 git clean -f
-git checkout "$RUST_COMMIT"
+git checkout "$RUST_BRANCH"
 cd ..
 mkdir -p rust-build
 cd rust-build

--- a/build.sh
+++ b/build.sh
@@ -15,18 +15,18 @@ if ! which cmake; then
 fi
 
 cd "$WORKING_DIR"
-if [ ! -d "$WORKING_DIR/swift-llvm" ]; then
-    git clone https://github.com/apple/swift-llvm.git -b "$SWIFT_BRANCH"
+if [ ! -d "$WORKING_DIR/llvm-project" ]; then
+    git clone https://github.com/apple/llvm-project.git -b "$LLVM_BRANCH"
 fi
-cd "$WORKING_DIR/swift-llvm"
+cd "$WORKING_DIR/llvm-project"
 git reset --hard
 git clean -f
-git checkout "origin/$SWIFT_BRANCH"
+git checkout "origin/$LLVM_BRANCH"
 cd ..
 
 mkdir -p llvm-build
 cd llvm-build
-cmake "$WORKING_DIR/swift-llvm" -DCMAKE_INSTALL_PREFIX="$WORKING_DIR/llvm-root" -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64' -G Ninja
+cmake "$WORKING_DIR/llvm-project/llvm" -DCMAKE_INSTALL_PREFIX="$WORKING_DIR/llvm-root" -DCMAKE_BUILD_TYPE=Release -DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64' -G Ninja
 ninja
 ninja install
 

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@
 
 # There is a branch called "stable" which looks promising
 # At this time (running Xcode 11.3) it's a couple of months newer than the 5.1 branch
-SWIFT_BRANCH="stable"
+LLVM_BRANCH="apple/stable/20190619"
 
 # 2. Pick/install a working Rust nightly (ideally one where RLS and clippy built)
 # 3. Note its date

--- a/config.sh
+++ b/config.sh
@@ -1,18 +1,18 @@
-# 1. Select the best branch from https://github.com/apple/llvm-project
-
+# 1. Select the best branch, tag or commit hash from https://github.com/apple/llvm-project
+# The recommended approach is to use the tagged release that matches the Swift version
+# returned by the command below (at this time running Xcode Version 11.3.1 (11C504))
 # $ xcrun -sdk iphoneos swiftc --version
-# Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)
-# Target: x86_64-apple-darwin19.0.0
+# Apple Swift version 5.1.3 (swiftlang-1100.0.282.1 clang-1100.0.33.15)
+# Target: x86_64-apple-darwin19.3.0
 
-# There is a branch called "apple/stable/20190619" which is equivalent to the "stable"
-# Branch under https://github.com/apple/swift-llvm under which looks promising.
-# At this time (running Xcode 11.3) it's a couple of months newer than the 5.1 branch
-LLVM_BRANCH="apple/stable/20190619"
+LLVM_BRANCH="tags/swift-5.1.3-RELEASE"
 
-# 2. Pick/install a working Rust nightly (ideally one where RLS and clippy built)
-# 3. Note its date
-RUST_NIGHTLY="2019-12-16"
+# 2. Select the best branch, tag or commit hash from https://github.com/rust-lang/rust
+# The stable 1.40.0 version of Rust seems to work
 
-# 4. Get its commit - this is what we will check out to build the iOS version
-# rustc --version | cut -d '(' -f2 | cut -d ' ' -f1
-RUST_COMMIT="a605441e0"
+RUST_BRANCH="tags/1.40.0"
+
+# 3. Select a name for the toolchain you want to install as. The toolchain will be installed
+# under $HOME/.rust-ios-arm64/toolchain-$RUST_TOOLCHAIN
+
+RUST_TOOLCHAIN="1.40.0"

--- a/config.sh
+++ b/config.sh
@@ -1,10 +1,11 @@
-# 1. Select the best branch from https://github.com/apple/swift-llvm
+# 1. Select the best branch from https://github.com/apple/llvm-project
 
 # $ xcrun -sdk iphoneos swiftc --version
 # Apple Swift version 5.1 (swiftlang-1100.0.270.13 clang-1100.0.33.7)
 # Target: x86_64-apple-darwin19.0.0
 
-# There is a branch called "stable" which looks promising
+# There is a branch called "apple/stable/20190619" which is equivalent to the "stable"
+# Branch under https://github.com/apple/swift-llvm under which looks promising.
 # At this time (running Xcode 11.3) it's a couple of months newer than the 5.1 branch
 LLVM_BRANCH="apple/stable/20190619"
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euxo
 source config.sh
 
 WORKING_DIR="$(pwd)/build"
-DEST_TOOLCHAIN="$HOME/.rust-ios-arm64/toolchain-$RUST_NIGHTLY"
+DEST_TOOLCHAIN="$HOME/.rust-ios-arm64/toolchain-$RUST_TOOLCHAIN"
 
 mkdir -p "$DEST_TOOLCHAIN"
 cp -r "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2"/* "$DEST_TOOLCHAIN"


### PR DESCRIPTION
The llvm subfolder under https://github.com/apple/llvm-project under the branch apple/stable/20190619 is equivalent to https://github.com/apple/swift-llvm on the stable branch. This switches out the repositories and branches