### PR TITLE
Problem: App Store rejects app containing Rust with bitcode error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,7 @@ cd rust
 git reset --hard
 git clean -f
 git checkout "$RUST_BRANCH"
+git apply ../../patches/rust_embed_cmdline.diff
 cd ..
 mkdir -p rust-build
 cd rust-build

--- a/config.sh
+++ b/config.sh
@@ -16,3 +16,4 @@ RUST_BRANCH="tags/1.40.0"
 # under $HOME/.rust-ios-arm64/toolchain-$RUST_TOOLCHAIN
 
 RUST_TOOLCHAIN="1.40.0"
+

--- a/patches/rust_embed_cmdline.diff
+++ b/patches/rust_embed_cmdline.diff
@@ -1,0 +1,15 @@
+diff --git a/src/librustc_codegen_llvm/back/write.rs b/src/librustc_codegen_llvm/back/write.rs
+index 52f3a1cbb5c..6014a1d8ade 100644
+--- a/src/librustc_codegen_llvm/back/write.rs
++++ b/src/librustc_codegen_llvm/back/write.rs
+@@ -686,7 +686,9 @@ unsafe fn embed_bitcode(cgcx: &CodegenContext<LlvmCodegenBackend>,
+     llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
+     llvm::LLVMSetGlobalConstant(llglobal, llvm::True);
+ 
+-    let llconst = common::bytes_in_context(llcx, &[]);
++    let args = "-triple\0arm64-apple-ios11.0.0\0-emit-obj\0\
++        -disable-llvm-passes\0-target-abi\0darwinpcs\0-Os\0";
++    let llconst = common::bytes_in_context(llcx, args.as_bytes());
+     let llglobal = llvm::LLVMAddGlobal(
+         llmod,
+         common::val_ty(llconst),


### PR DESCRIPTION
There is a python program used by Apple (included inside the Xcode.app bundle) which verifies a program's bitcode as part of rebuilding it. It includes a check that each bitcode object has valid clang parameters included as part of its XML xar header.

The Rust compiler sensibly chooses not to emit any clang parameters, since it is not clang. Unfortunately this means any Rust-emitted bitcode will not pass app store verification.

Locally, it produces an error like this one:

```
error: Clang option verification failed for bitcode 0038
(argument -emit-obj is required)
```

Through App Connect, it produces an error like this one:

```
ITMS-90562: Invalid Bundle - The app cannot be processed because options not
allowed to be embedded in bitcode are detected in the submission
```

**Solution:** Patch Rust so that it will embed exactly the same clang cmdline that Xcode/clang will when emitting Bitcode.

This patch is relatively brittle and not upstreamable in this form, but it serves well to demonstrate the problem and is likely to be a workable solution for now for anyone who wants to ship code.