### PR TITLE
Prep for 1.43.0 update and fix openssl linkage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,12 @@
 set -euxo
 source config.sh
 
-WORKING_DIR="$(pwd)/build"
-mkdir -p "$WORKING_DIR"
-
+export OPENSSL_STATIC=1
+export OPENSSL_DIR=/usr/local/opt/openssl
+if [ ! -d "$OPENSSL_DIR" ]; then
+    echo "OpenSSL not found at expected location. Try: brew install openssl"
+    exit 1
+fi
 if ! which ninja; then
     echo "ninja not found. Try: brew install ninja"
     exit 1
@@ -13,6 +16,9 @@ if ! which cmake; then
     echo "cmake not found. Try: brew install cmake"
     exit 1
 fi
+
+WORKING_DIR="$(pwd)/build"
+mkdir -p "$WORKING_DIR"
 
 cd "$WORKING_DIR"
 if [ ! -d "$WORKING_DIR/llvm-project" ]; then

--- a/config.sh
+++ b/config.sh
@@ -5,15 +5,15 @@
 # Apple Swift version 5.1.3 (swiftlang-1100.0.282.1 clang-1100.0.33.15)
 # Target: x86_64-apple-darwin19.3.0
 
-LLVM_BRANCH="tags/swift-5.1.3-RELEASE"
+LLVM_BRANCH="tags/swift-5.2.3-RELEASE"
 
 # 2. Select the best branch, tag or commit hash from https://github.com/rust-lang/rust
 # The stable 1.40.0 version of Rust seems to work
 
-RUST_BRANCH="tags/1.40.0"
+RUST_BRANCH="tags/1.43.0"
 
 # 3. Select a name for the toolchain you want to install as. The toolchain will be installed
 # under $HOME/.rust-ios-arm64/toolchain-$RUST_TOOLCHAIN
 
-RUST_TOOLCHAIN="1.40.0"
+RUST_TOOLCHAIN="1.43.0"
 


### PR DESCRIPTION
I've confirmed this config works with Xcode 11.4.1, including compiling and installing bitcode apps and doing a rebuild from bitcode (which exercises Apple's validator script).

Also fixes #8, which might be helpful for deploying the binary release to a machine that doesn't have homebrew.