### PR TITLE
Added support for 32-bit bitcode targets

### DIFF
--- a/patches/rust_embed_cmdline.diff
+++ b/patches/rust_embed_cmdline.diff
@@ -1,14 +1,31 @@
 diff --git a/src/librustc_codegen_llvm/back/write.rs b/src/librustc_codegen_llvm/back/write.rs
-index 52f3a1cbb5c..6014a1d8ade 100644
+index 0c243128104..514ef813b43 100644
 --- a/src/librustc_codegen_llvm/back/write.rs
 +++ b/src/librustc_codegen_llvm/back/write.rs
-@@ -686,7 +686,9 @@ unsafe fn embed_bitcode(cgcx: &CodegenContext<LlvmCodegenBackend>,
+@@ -848,12 +848,26 @@ unsafe fn embed_bitcode(
+     let is_apple = cgcx.opts.target_triple.triple().contains("-ios")
+         || cgcx.opts.target_triple.triple().contains("-darwin");
+
++    let mut triple = String::from(cgcx.opts.target_triple.triple());
++    let mut abi = "darwinpcs";
++    if triple == "aarch64-apple-ios" {
++        triple = String::from("arm64-apple-ios");
++    } else if triple == "armv7-apple-ios" {
++        triple = String::from("thumbv7-apple-ios");
++        abi = "apcs-gnu";
++    }
++    if triple.contains("-ios") {
++        triple.push_str("9.0.0");
++    }
++
+     let section = if is_apple { "__LLVM,__bitcode\0" } else { ".llvmbc\0" };
+     llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
      llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
      llvm::LLVMSetGlobalConstant(llglobal, llvm::True);
- 
+
 -    let llconst = common::bytes_in_context(llcx, &[]);
-+    let args = "-triple\0arm64-apple-ios11.0.0\0-emit-obj\0\
-+        -disable-llvm-passes\0-target-abi\0darwinpcs\0-Os\0";
++    let args = format!("-triple\0{}\0-emit-obj\0\
++        -disable-llvm-passes\0-target-abi\0{}\0-Os\0", triple, abi);
 +    let llconst = common::bytes_in_context(llcx, args.as_bytes());
      let llglobal = llvm::LLVMAddGlobal(
          llmod,


### PR DESCRIPTION
We use a deployment target of iOS 9, which is why we append 9.0.0.

I'm happy to change this to be 11.0.0 (as it was originally). I've also modified the build script since we build for 32 and 64-bit targets and simulators, and also build for 32/64 bit android targets. That way our shared code is built using the same toolchain. If interested, I'd be happy to try and bundle up those changes (perhaps make the targets selectable using config.sh?)