### PR TITLE
Pin-point the Rust version of the toolchain from stable to 1.46.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This will install the toolchain in `~/.rustup/toolchains/ios-arm64-xxx`.
    repositories under `build/` and compile them. The toolchain will end up
    at `build/rust-build/build/x86_64-apple-darwin/stage2`.
 5. Run `./install.sh`. This will install the toolchain in
-   `~/.rustup/toolchains/rust-ios-arm64-1.46.0`, making it available in rustup.
+   `~/.rustup/toolchains/ios-arm64-1.46.0`, making it available in rustup.
 
 ## Using the toolchain
 

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,6 @@ git checkout "$RUST_BRANCH"
 cd ..
 mkdir -p rust-build
 cd rust-build
-../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios --enable-extended --tools=cargo --release-channel=stable
+../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios --enable-extended --tools=cargo --release-channel=1.46.0
 export CFLAGS_aarch64_apple_ios=-fembed-bitcode
 python "$WORKING_DIR/rust/x.py" build

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,6 @@ git checkout "$RUST_BRANCH"
 cd ..
 mkdir -p rust-build
 cd rust-build
-../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios --enable-extended --tools=cargo --release-channel=1.46.0
+../rust/configure --llvm-config="$WORKING_DIR/llvm-root/bin/llvm-config" --target=aarch64-apple-ios --enable-extended --tools=cargo --release-channel="$RUST_RELEASE_CHANNEL"
 export CFLAGS_aarch64_apple_ios=-fembed-bitcode
 python "$WORKING_DIR/rust/x.py" build

--- a/config.sh
+++ b/config.sh
@@ -9,7 +9,11 @@ LLVM_BRANCH="tags/swift-5.3-RELEASE"
 
 RUST_BRANCH="tags/1.46.0"
 
-# 3. Select a name for the toolchain you want to install as. The toolchain will be installed
+# 3. Pick the rust compiler and std version that matches `2.`
+
+RUST_RELEASE_CHANNEL="1.46.0"
+
+# 4. Select a name for the toolchain you want to install as. The toolchain will be installed
 # under $HOME/.rustup/toolchains/rust-$RUST_TOOLCHAIN
 
 RUST_TOOLCHAIN="ios-arm64-1.46.0"


### PR DESCRIPTION
This seems to fix https://github.com/getditto/ditto/issues/2460, where the installed `+ios-arm64-1.46.0` had maybe been built with a more recent version of the Rust standard library?

@thombles what do you think?