### PR TITLE
fix: installation on M1 Mac

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
+
 set -euxo
+
 source config.sh
 
 WORKING_DIR="$(pwd)/build"
-DEST_TOOLCHAIN="$HOME/.rustup/toolchains/$RUST_TOOLCHAIN"
+RUST_TARGET_ARCH="$(rustc --print cfg | grep target_arch | awk -F= '{ print $2 }' | tr -d '"')"
 
-# Remove unneeded files from output
-rm -rf "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2/lib/rustlib/src"
+STAGE_DIR="${WORKING_DIR}/rust-build/build/${RUST_TARGET_ARCH}-apple-darwin/stage2"
 
-rm -rf "$DEST_TOOLCHAIN"
-mkdir -p "$DEST_TOOLCHAIN"
-cp -r "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2"/* "$DEST_TOOLCHAIN"
-cp -r "$WORKING_DIR/rust-build/build/x86_64-apple-darwin/stage2-tools/x86_64-apple-darwin/release/cargo" "$DEST_TOOLCHAIN/bin"
+# remove unnecessary files from output
 
-echo "Installed bitcode-enabled Rust toolchain. Use with: +$RUST_TOOLCHAIN"
+rm -rf "${STAGE_DIR}/lib/rustlib/src"
+
+# setup toolchain directory
+
+DEST_TOOLCHAIN="${HOME}/.rustup/toolchains/${RUST_TOOLCHAIN}"
+
+rm -rf "${DEST_TOOLCHAIN}"
+mkdir -p "${DEST_TOOLCHAIN}"
+
+# install artifacts
+
+cp -r "${STAGE_DIR}"/* "${DEST_TOOLCHAIN}"
+cp -r "${STAGE_DIR}-tools/${RUST_TARGET_ARCH}-apple-darwin/release/cargo" "${DEST_TOOLCHAIN}/bin"
+
+echo "Installed bitcode-enabled Rust toolchain. Use with: +${RUST_TOOLCHAIN}"


### PR DESCRIPTION
This PR attempts to fix this problem on a M1 mac:

```bash
+ cp -r 'SOMEPATH/rust-bitcode/build/rust-build/build/x86_64-apple-darwin/stage2/*' /Users/steenzout/.rustup/toolchains/ios-arm64-1.60.0
cp: SOMEPATH/rust-bitcode/build/rust-build/build/x86_64-apple-darwin/stage2/*: No such file or directory
```

## Testing

```bash
% bash install.sh 
allexport      	off
braceexpand    	on
emacs          	off
errexit        	on
errtrace       	off
functrace      	off
hashall        	on
histexpand     	off
history        	off
ignoreeof      	off
interactive-comments	on
keyword        	off
monitor        	off
noclobber      	off
noexec         	off
noglob         	off
nolog          	off
notify         	off
nounset        	on
onecmd         	off
physical       	off
pipefail       	off
posix          	off
privileged     	off
verbose        	off
vi             	off
xtrace         	on
+ source config.sh
++ set -euxo pipefail
++ RUST_TOOLCHAIN=1.60.0
++ LLVM_BRANCH=bda51ce411586a8c012623300d8598ce84fced53
+++ get_rust_commit_for_toolchain
++++ echo 1.60.0
++++ sed -n 's/^nightly-//p'
+++ IF_NIGHTLY_DATE_STRIPPED=
+++ '[' -n '' ']'
+++ echo refs/tags/1.60.0
++ RUST_BRANCH=refs/tags/1.60.0
++ RUST_TOOLCHAIN=ios-arm64-1.60.0
++ pwd
+ WORKING_DIR=SOMEPATH/getditto/rust-bitcode/build
++ rustc --print cfg
++ grep target_arch
++ awk -F= '{ print $2 }'
++ tr -d '"'
+ RUST_TARGET_ARCH=aarch64
+ STAGE_DIR=SOMEPATH/getditto/rust-bitcode/build/rust-build/build/aarch64-apple-darwin/stage2
+ rm -rf SOMEPATH/getditto/rust-bitcode/build/rust-build/build/aarch64-apple-darwin/stage2/lib/rustlib/src
+ DEST_TOOLCHAIN=HOME/.rustup/toolchains/ios-arm64-1.60.0
+ rm -rf HOME/.rustup/toolchains/ios-arm64-1.60.0
+ mkdir -p HOME/.rustup/toolchains/ios-arm64-1.60.0
+ cp -r SOMEPATH/getditto/rust-bitcode/build/rust-build/build/aarch64-apple-darwin/stage2/bin SOMEPATH/getditto/rust-bitcode/build/rust-build/build/aarch64-apple-darwin/stage2/lib HOME/.rustup/toolchains/ios-arm64-1.60.0
+ cp -r SOMEPATH/getditto/rust-bitcode/build/rust-build/build/aarch64-apple-darwin/stage2-tools/aarch64-apple-darwin/release/cargo HOME/.rustup/toolchains/ios-arm64-1.60.0/bin
+ echo 'Installed bitcode-enabled Rust toolchain. Use with: +ios-arm64-1.60.0'
Installed bitcode-enabled Rust toolchain. Use with: +ios-arm64-1.60.0
```
